### PR TITLE
Add theme toggle and bilingual content

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,80 +3,142 @@ import { useContext } from "react";
 import { LanguageContext } from "@/contexts/LanguageContext";
 import { translations } from "@/data/translations";
 
+const aboutContent = {
+  en: {
+    sections: [
+      {
+        title: "Professional Summary",
+        paragraphs: [
+          "Full-Stack Developer with 7+ years of experience delivering scalable web applications and cloud-based solutions using .NET and modern JavaScript frameworks.",
+          "Proven ability to build robust APIs, manage cloud infrastructure (Azure/AWS), and lead cross-functional teams in Agile environments.",
+          "Skilled in both frontend and backend development, with a strong focus on clean architecture, performance, and maintainability."
+        ]
+      },
+      {
+        title: "Personal Information",
+        paragraphs: [
+          "Name: Sergio Demarco",
+          "Birth Date: 10/01/1994",
+          "Nationality: Argentine",
+          "Marital Status: Married"
+        ]
+      },
+      {
+        title: "Education",
+        paragraphs: [
+          "(2017 – Dec 2020): Technical degree in mobile and web application development, Universidad Nacional de La Matanza, Buenos Aires.",
+          "(2011 – Dec 2012): Aeronautical Technician, Technician School 'Jorge Newbery' N°8, Buenos Aires.",
+          "(2007 – Dec 2011): Mechanic in Aircraft Maintenance, Technician School 'Jorge Newbery' N°8, Buenos Aires.",
+          "(2014 – Jun 2016): Cyber Security, Educación IT, Buenos Aires."
+        ]
+      },
+      {
+        title: "Languages",
+        paragraphs: ["English: C1", "Spanish: Native", "Italian: A2"]
+      },
+      {
+        title: "Skills and Technologies",
+        paragraphs: [
+          ".NET, C#, TypeScript, JavaScript, React, Next.js, Angular, Node.js, ASP.NET, MVC, WebAPI, SQL Server, MongoDB, Cosmos DB, Azure, AWS, Docker, Git, WCF, Microservices, RabbitMQ, Agile, Team leadership, CI/CD."
+        ]
+      },
+      {
+        title: "Other Information",
+        paragraphs: [
+          "Aircraft Maintenance License Nº: 95237",
+          "Driver's License: Argentina (B1) and Florida (USA)"
+        ]
+      }
+    ],
+    download: {
+      title: "Download CV",
+      description: "You can download my full resume in PDF format.",
+      button: "Download CV"
+    }
+  },
+  es: {
+    sections: [
+      {
+        title: "Resumen Profesional",
+        paragraphs: [
+          "Desarrollador Full-Stack con más de 7 años de experiencia en la entrega de aplicaciones web escalables y soluciones en la nube utilizando .NET y frameworks modernos de JavaScript.",
+          "Capacidad probada para crear APIs robustas, administrar infraestructura cloud (Azure/AWS) y liderar equipos multifuncionales en entornos Ágiles.",
+          "Competente en desarrollo frontend y backend, con fuerte enfoque en arquitectura limpia, rendimiento y mantenibilidad."
+        ]
+      },
+      {
+        title: "Información Personal",
+        paragraphs: [
+          "Nombre: Sergio Demarco",
+          "Fecha de Nacimiento: 10/01/1994",
+          "Nacionalidad: Argentina",
+          "Estado Civil: Casado"
+        ]
+      },
+      {
+        title: "Educación",
+        paragraphs: [
+          "(2017 – Dic 2020): Tecnicatura en desarrollo de aplicaciones móviles y web, Universidad Nacional de La Matanza, Buenos Aires.",
+          "(2011 – Dic 2012): Técnico Aeronáutico, Escuela Técnica 'Jorge Newbery' N°8, Buenos Aires.",
+          "(2007 – Dic 2011): Mecánico en Mantenimiento de Aeronaves, Escuela Técnica 'Jorge Newbery' N°8, Buenos Aires.",
+          "(2014 – Jun 2016): Ciberseguridad, Educación IT, Buenos Aires."
+        ]
+      },
+      {
+        title: "Idiomas",
+        paragraphs: ["Inglés: C1", "Español: Nativo", "Italiano: A2"]
+      },
+      {
+        title: "Habilidades y Tecnologías",
+        paragraphs: [
+          ".NET, C#, TypeScript, JavaScript, React, Next.js, Angular, Node.js, ASP.NET, MVC, WebAPI, SQL Server, MongoDB, Cosmos DB, Azure, AWS, Docker, Git, WCF, Microservicios, RabbitMQ, Agile, Liderazgo de equipos, CI/CD."
+        ]
+      },
+      {
+        title: "Otros Datos de Interés",
+        paragraphs: [
+          "Licencia de Mecánico en Mantenimiento de Aeronaves Nº: 95237",
+          "Licencia de Conducir: Argentina (B1) y Florida (USA)"
+        ]
+      }
+    ],
+    download: {
+      title: "Descargar CV",
+      description: "Puedes descargar mi curriculum completo en formato PDF.",
+      button: "Descargar CV"
+    }
+  }
+};
+
 export default function About() {
-    const { lang } = useContext(LanguageContext);
-    return (
-        <main className="min-h-screen p-6 pt-8 sm:pt-24">
-            <div className="max-w-4xl mx-auto">
-                <h1 className="text-4xl font-bold text-neutral-100 mb-8">{translations[lang].about.title}</h1>
-                <div className="space-y-6 text-lg text-neutral-300">
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Información Personal</h2>
-                        <p>
-                            <span className="font-semibold">Nombre:</span> Sergio Demarco
-                        </p>
-                        <p>
-                            <span className="font-semibold">Fecha de Nacimiento:</span> 10/01/1994
-                        </p>
-                        <p>
-                            <span className="font-semibold">Nacionalidad:</span> Argentina
-                        </p>
-                        <p>
-                            <span className="font-semibold">Estado Civil:</span> Casado
-                        </p>
-                    </section>
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Educación</h2>
-                        <p>
-                            <span className="font-semibold">(2017 – Dec 2020):</span> Técnico en desarrollo de aplicaciones móviles y web, Universidad Nacional de la Matanza, Buenos Aires.
-                        </p>
-                        <p>
-                            <span className="font-semibold">(2011 – Dec 2012):</span> Técnico Aeronáutico, Escuela Técnica “Jorge Newbery” N°8, Buenos Aires.
-                        </p>
-                        <p>
-                            <span className="font-semibold">(2007 – Dec 2011):</span> Mecánico en Mantenimiento de Aeronaves, Escuela Técnica “Jorge Newbery” N°8, Buenos Aires.
-                        </p>
-                        <p>
-                            <span className="font-semibold">(2014 – Dec 2016):</span> Ciberseguridad, Educación IT, Buenos Aires.
-                        </p>
-                    </section>
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Idiomas</h2>
-                        <p>
-                            <span className="font-semibold">Inglés:</span> Avanzado (Instituto Británico de Cultura Inglesa, Ramos Mejía, Buenos Aires)
-                        </p>
-                    </section>
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Habilidades y Tecnologías</h2>
-                        <p>
-                            <span className="font-semibold">Top Skills:</span> .NET, .NET Core, React (con TypeScript), ASP/ASPX, API Restful, HTML/CSS, SOAP, Microservicios, Entity Framework, SQL/NoSQL, Azure, NodeJS, Angular, AWS, Git, SignalR, RabbitMQ, MemCache, Firebase, ReactNative, CI/CD, Docker, Terraform, Kubernetes, Flutter, Kotlin, Swift, Desarrollo de Criptomonedas (Remix y Solidity)
-                        </p>
-                    </section>
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Otros Datos de Interés</h2>
-                        <p>
-                            <span className="font-semibold">Licencia de Mecánico en Mantenimiento de Aeronaves Nº:</span> 95237
-                        </p>
-                        <p>
-                            <span className="font-semibold">Licencia de Conducir:</span> Argentina (Clase B1) y Florida (USA)
-                        </p>
-                    </section>
-                    {/* Nueva sección para descargar el CV */}
-                    <section>
-                        <h2 className="text-2xl font-bold text-neutral-200">Descargar CV</h2>
-                        <p className="mt-4">
-                            Puedes descargar mi curriculum completo en formato PDF.
-                        </p>
-                        <a
-                            href="/cv.pdf"
-                            download
-                            className="mt-4 inline-block bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
-                        >
-                            Descargar CV
-                        </a>
-                    </section>
-                </div>
-            </div>
-        </main>
-    );
+  const { lang } = useContext(LanguageContext);
+  const content = aboutContent[lang];
+  return (
+    <main className="min-h-screen p-6 pt-8 sm:pt-24">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-neutral-100 mb-8">{translations[lang].about.title}</h1>
+        <div className="space-y-6 text-lg text-gray-700 dark:text-neutral-300">
+          {content.sections.map((section, idx) => (
+            <section key={idx} className="space-y-2">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-neutral-200">{section.title}</h2>
+              {section.paragraphs.map((p, i) => (
+                <p key={i}>{p}</p>
+              ))}
+            </section>
+          ))}
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-neutral-200">{content.download.title}</h2>
+            <p className="mt-4">{content.download.description}</p>
+            <a
+              href="/cv.pdf"
+              download
+              className="mt-4 inline-block bg-[var(--primary)] text-white px-4 py-2 rounded hover:opacity-90"
+            >
+              {content.download.button}
+            </a>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,8 +8,8 @@ export default function Contact() {
     return (
         <main className="min-h-screen p-6 pt-8 sm:pt-24">
             <div className="max-w-3xl mx-auto">
-                <h1 className="text-4xl font-bold text-neutral-100 mb-8">{translations[lang].contact.title}</h1>
-                <div className="space-y-4 text-lg text-neutral-300">
+                <h1 className="text-4xl font-bold text-gray-900 dark:text-neutral-100 mb-8">{translations[lang].contact.title}</h1>
+                <div className="space-y-4 text-lg text-gray-700 dark:text-neutral-300">
                     <p>
                         <span className="font-semibold">Email:</span>{" "}
                         <a

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,9 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+html.light {
+  --background: #ffffff;
+  --foreground: #000000;
+  --primary: #4570B5;
+}
+html.dark {
   --background: #111111;
   --foreground: #e5e5e5;
+  --primary: #4570B5;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import { LanguageProvider } from "@/contexts/LanguageContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 export const metadata: Metadata = {
   title: "My Portfolio",
@@ -18,11 +19,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
-      <body className="font-sans bg-neutral-900 text-neutral-200 antialiased">
-        <LanguageProvider>
-          <Navbar />
-          <div className="pt-20">{children}</div>
-        </LanguageProvider>
+      <body className="font-sans antialiased">
+        <ThemeProvider>
+          <LanguageProvider>
+            <Navbar />
+            <div className="pt-20">{children}</div>
+          </LanguageProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function HomePage() {
   const { lang } = useContext(LanguageContext);
   return (
     <div className="min-h-screen py-20 px-4">
-      <h1 className="text-4xl font-bold text-center mb-12">
+      <h1 className="text-4xl font-bold text-center mb-12 text-gray-900 dark:text-neutral-100">
         {translations[lang].home.title}
       </h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-5xl mx-auto">

--- a/src/app/projects/novatech/page.tsx
+++ b/src/app/projects/novatech/page.tsx
@@ -18,7 +18,7 @@ export default function NovatechPage() {
                 <Link href="/" className="text-indigo-600 hover:underline">&larr; {translations[lang].novatech.back}</Link>
 
                 <motion.h1
-                    className="text-4xl font-bold text-neutral-100"
+                    className="text-4xl font-bold text-gray-900 dark:text-neutral-100"
                     initial="hidden"
                     animate="visible"
                     variants={fadeInUp}
@@ -28,7 +28,7 @@ export default function NovatechPage() {
                 </motion.h1>
 
                 <motion.p
-                    className="text-lg text-neutral-300"
+                    className="text-lg text-gray-700 dark:text-neutral-300"
                     initial="hidden"
                     animate="visible"
                     variants={fadeInUp}
@@ -38,14 +38,14 @@ export default function NovatechPage() {
                 </motion.p>
 
                 <motion.div
-                    className="bg-gray-800 rounded-lg shadow-md p-6"
+                    className="bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md p-6"
                     initial="hidden"
                     animate="visible"
                     variants={fadeInUp}
                     transition={{ duration: 0.8, delay: 0.4 }}
                 >
-                    <h2 className="text-xl font-semibold text-neutral-100 mb-2">Tecnologías clave</h2>
-                    <ul className="list-disc list-inside text-neutral-300 space-y-1">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-neutral-100 mb-2">Tecnologías clave</h2>
+                    <ul className="list-disc list-inside text-gray-700 dark:text-neutral-300 space-y-1">
                         <li>.NET & .NET Core</li>
                         <li>Next.js + TypeScript</li>
                         <li>Azure (App Services, Functions, CI/CD)</li>
@@ -54,7 +54,7 @@ export default function NovatechPage() {
                 </motion.div>
 
                 <motion.div
-                    className="text-sm text-gray-400"
+                    className="text-sm text-gray-600 dark:text-gray-400"
                     initial="hidden"
                     animate="visible"
                     variants={fadeInUp}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -56,26 +56,26 @@ export default function Work() {
     return (
         <main className="min-h-screen p-6 pt-8 sm:pt-24">
             <div className="max-w-4xl mx-auto">
-                <h1 className="text-4xl font-bold text-neutral-100 mb-8">
+                <h1 className="text-4xl font-bold text-gray-900 dark:text-neutral-100 mb-8">
                     {translations[lang].work.title}
                 </h1>
                 <div className="space-y-8">
                     {workExperience.map((job) => (
-                        <div key={job.id} className="bg-gray-800 p-6 rounded-lg shadow">
+                        <div key={job.id} className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow">
                             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
                                 <div>
-                                    <h2 className="text-2xl font-bold text-neutral-200">
+                                    <h2 className="text-2xl font-bold text-gray-900 dark:text-neutral-200">
                                         {job.company}
                                     </h2>
-                                    <p className="text-gray-400">{job.role}</p>
+                                    <p className="text-gray-600 dark:text-gray-400">{job.role}</p>
                                 </div>
-                                <span className="text-sm text-gray-400">{job.period}</span>
+                                <span className="text-sm text-gray-600 dark:text-gray-400">{job.period}</span>
                             </div>
                             <div className="mt-4">
-                                <p className="text-gray-300">
+                                <p className="text-gray-700 dark:text-gray-300">
                                     <span className="font-semibold">Tech:</span> {job.tech}
                                 </p>
-                                <p className="mt-2 text-gray-300">{job.tasks}</p>
+                                <p className="mt-2 text-gray-700 dark:text-gray-300">{job.tasks}</p>
                             </div>
                         </div>
                     ))}

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -15,14 +15,14 @@ export default function ExperienceCard({ experience }: Props) {
     return (
         <motion.div
             layout
-            className="bg-gray-800 rounded-xl shadow-lg p-6 cursor-pointer"
+            className="bg-gray-100 dark:bg-gray-800 rounded-xl shadow-lg p-6 cursor-pointer"
             onClick={toggle}
         >
             <div className="flex items-start justify-between">
                 <div>
-                    <h3 className="text-xl font-semibold text-white">{experience.title}</h3>
-                    <p className="text-sm text-gray-400 mt-1">{experience.company}</p>
-                    <p className="text-sm mt-2 text-gray-300">{experience.period}</p>
+                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{experience.title}</h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{experience.company}</p>
+                    <p className="text-sm mt-2 text-gray-700 dark:text-gray-300">{experience.period}</p>
                 </div>
                 <ChevronDown className={`mt-1 transition-transform ${open ? "rotate-180" : "rotate-0"}`} />
             </div>
@@ -33,7 +33,7 @@ export default function ExperienceCard({ experience }: Props) {
                         animate={{ opacity: 1, height: "auto" }}
                         exit={{ opacity: 0, height: 0 }}
                         transition={{ duration: 0.3 }}
-                        className="mt-4 list-disc list-inside text-sm text-gray-300 space-y-1"
+                        className="mt-4 list-disc list-inside text-sm text-gray-700 dark:text-gray-300 space-y-1"
                     >
                         {experience.responsibilities.map((item, index) => (
                             <li key={index}>{item}</li>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,13 +2,15 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useContext } from "react";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Sun, Moon } from "lucide-react";
 import { LanguageContext } from "@/contexts/LanguageContext";
+import { ThemeContext } from "@/contexts/ThemeContext";
 import { translations } from "@/data/translations";
 
 export default function Navbar() {
   const pathname = usePathname();
   const { lang, setLang } = useContext(LanguageContext);
+  const { theme, toggleTheme } = useContext(ThemeContext);
   const [open, setOpen] = useState(false);
   const navItems = [
     { name: translations[lang].nav.home, href: "/" },
@@ -18,7 +20,9 @@ export default function Navbar() {
   ];
 
   return (
-    <header className="fixed top-0 left-0 w-full z-50 bg-gradient-to-r from-gray-950 via-gray-900 to-gray-950/90 backdrop-blur">
+    <header
+      className={`fixed top-0 left-0 w-full z-50 ${theme === "light" ? "bg-[#4570B5]" : "bg-gradient-to-r from-gray-950 via-gray-900 to-gray-950/90 backdrop-blur"}`}
+    >
       <div className="max-w-6xl mx-auto flex items-center justify-between px-4 py-3">
         <Link href="/" className="font-bold text-lg text-white">
           Sergio
@@ -33,6 +37,12 @@ export default function Navbar() {
               {name}
             </Link>
           ))}
+          <button
+            onClick={toggleTheme}
+            className="text-sm text-gray-400 hover:text-white"
+          >
+            {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
+          </button>
           <button
             onClick={() => setLang(lang === "en" ? "es" : "en")}
             className="text-sm text-gray-400 hover:text-white"
@@ -56,12 +66,20 @@ export default function Navbar() {
               {name}
             </Link>
           ))}
-          <button
-            onClick={() => setLang(lang === "en" ? "es" : "en")}
-            className="mt-2 text-sm self-start text-gray-400 hover:text-white"
-          >
-            {lang === "en" ? "ES" : "EN"}
-          </button>
+          <div className="flex gap-4 mt-2">
+            <button
+              onClick={toggleTheme}
+              className="text-sm text-gray-400 hover:text-white"
+            >
+              {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
+            </button>
+            <button
+              onClick={() => setLang(lang === "en" ? "es" : "en")}
+              className="text-sm text-gray-400 hover:text-white"
+            >
+              {lang === "en" ? "ES" : "EN"}
+            </button>
+          </div>
         </nav>
       )}
     </header>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { createContext, useState, useEffect, ReactNode } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextProps>({
+  theme: "light",
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+  const toggleTheme = () => setTheme((t) => (t === "light" ? "dark" : "light"));
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove(theme === "light" ? "dark" : "light");
+    root.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "tailwindcss";
 import plugin from "tailwindcss/plugin";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode via class
- add ThemeContext and ThemeProvider
- apply theme styles in layout, global CSS and Navbar
- introduce bilingual About page with professional info
- update pages and components for light/dark styling

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686341b0a3e4832e91403cef73d49947