### PR TITLE
Add complete job experiences

### DIFF
--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -2,56 +2,10 @@
 import { useContext } from "react";
 import { LanguageContext } from "@/contexts/LanguageContext";
 import { translations } from "@/data/translations";
+import { experiences } from "@/data/experiences";
 
 export default function Work() {
     const { lang } = useContext(LanguageContext);
-    const workExperience = [
-        {
-            id: 1,
-            period: "April 2022 – Present",
-            company: "Novatech (for Milwaukee Tools)",
-            role: "Full-Stack Developer",
-            tech: ".NET, Next.js, Azure",
-            tasks:
-                "Desarrollo de endpoints en .NET, creación de frontends dinámicos basados en diseños Figma, gestión de infraestructura Azure y mentoría de desarrolladores junior.",
-        },
-        {
-            id: 2,
-            period: "April 2022 – June 2023",
-            company: "Selehann (for iDocket)",
-            role: ".NET Senior Developer",
-            tech: ".NET, .NET Core, ASP Web, AWS, MySQL",
-            tasks:
-                "Diseño y migración de microservicios a .NET Core, definición de arquitectura y mejora de procesos de desarrollo.",
-        },
-        {
-            id: 3,
-            period: "February 2021 – April 2022",
-            company: "The Bridge (for Grace Kennedy Financial Group)",
-            role: ".NET Senior Developer",
-            tech: ".NET, .NET Core, React, NodeJS, Azure, Docker",
-            tasks:
-                "Diseño de APIs, desarrollo de endpoints para equipos de front-end y construcción de soluciones escalables en la nube, incluyendo integración con criptomonedas.",
-        },
-        {
-            id: 4,
-            period: "April 2019 – February 2021",
-            company: "Urbetrack",
-            role: "Tech Leader & .NET Developer",
-            tech: ".NET, .NET Core, ASP, RabbitMQ, React, Angular, NodeJS, SQL",
-            tasks:
-                "Liderazgo de equipo en soluciones de tracking satelital, desarrollo de Web APIs y gestión de proyectos ágiles.",
-        },
-        {
-            id: 5,
-            period: "September 2017 – April 2019",
-            company: "Globant (for JPMorgan Chase)",
-            role: ".NET Senior Developer",
-            tech: ".NET, .NET Core, SQL",
-            tasks:
-                "Desarrollo de nuevas funciones en MVC, mantenimiento de sistemas para usuarios internacionales y análisis de datos.",
-        },
-    ];
 
     return (
         <main className="min-h-screen p-6 pt-8 sm:pt-24">
@@ -60,8 +14,8 @@ export default function Work() {
                     {translations[lang].work.title}
                 </h1>
                 <div className="space-y-8">
-                    {workExperience.map((job) => (
-                        <div key={job.id} className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow">
+                    {experiences.map((job, index) => (
+                        <div key={index} className="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg shadow">
                             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
                                 <div>
                                     <h2 className="text-2xl font-bold text-gray-900 dark:text-neutral-200">

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -3,6 +3,9 @@ export interface Experience {
     company: string;
     period: string;
     responsibilities: string[];
+    role?: string;
+    tech?: string;
+    tasks?: string;
 }
 
 export const experiences: Experience[] = [
@@ -10,42 +13,83 @@ export const experiences: Experience[] = [
         title: "Full-Stack Developer",
         company: "Qualitara – Milwaukee Tools",
         period: "Jun 2023 – Present",
+        role: "Full-Stack Developer",
+        tech: ".NET, Next.js, Azure",
         responsibilities: [
             "Built reusable .NET APIs",
             "Implemented dynamic Next.js interfaces",
             "Managed Azure infrastructure",
             "Mentored junior developers",
         ],
+        tasks:
+            "Desarrollo de endpoints en .NET, creación de frontends dinámicos basados en diseños Figma, gestión de infraestructura Azure y mentoría de desarrolladores junior.",
     },
     {
         title: ".NET Senior Developer",
         company: "Selehann – iDocket",
         period: "Apr 2022 – Jun 2023",
+        role: ".NET Senior Developer",
+        tech: ".NET, .NET Core, ASP Web, AWS, MySQL",
         responsibilities: [
             "Migrated services to .NET Core",
             "Designed microservices with WCF",
             "Improved architecture for scalability",
         ],
+        tasks:
+            "Diseño y migración de microservicios a .NET Core, definición de arquitectura y mejora de procesos de desarrollo.",
     },
     {
         title: ".NET Senior Developer",
         company: "The Bridge – Grace Kennedy Financial",
         period: "Feb 2021 – Apr 2022",
+        role: ".NET Senior Developer",
+        tech: ".NET, .NET Core, React, NodeJS, Azure, Docker",
         responsibilities: [
             "Developed APIs for fintech solutions",
             "Designed architecture with Cosmos DB",
             "Collaborated on web and mobile platforms",
         ],
+        tasks:
+            "Diseño de APIs, desarrollo de endpoints para equipos de front-end y construcción de soluciones escalables en la nube, incluyendo integración con criptomonedas.",
     },
     {
         title: "Technical Lead / .NET Developer",
         company: "Urbetrack",
         period: "Apr 2019 – Feb 2021",
+        role: "Tech Leader & .NET Developer",
+        tech: ".NET, .NET Core, ASP, RabbitMQ, React, Angular, NodeJS, SQL",
         responsibilities: [
             "Led development teams",
             "Implemented real-time processing",
             "Managed Agile flows and DevOps",
         ],
+        tasks:
+            "Liderazgo de equipo en soluciones de tracking satelital, desarrollo de Web APIs y gestión de proyectos ágiles.",
     },
-    // Agregamos los restantes si querés incluirlos también
+    {
+        title: ".NET Senior Developer",
+        company: "Globant – JPMorgan Chase",
+        period: "Sep 2017 – Apr 2019",
+        role: ".NET Senior Developer",
+        tech: ".NET, .NET Core, SQL",
+        responsibilities: [
+            "Developed MVC features",
+            "Maintained systems for international users",
+            "Performed data analysis",
+        ],
+        tasks:
+            "Desarrollo de nuevas funciones en MVC, mantenimiento de sistemas para usuarios internacionales y análisis de datos.",
+    },
+    {
+        title: "Junior Developer",
+        company: "Just Solutions",
+        period: "Nov 2016 – Sep 2017",
+        role: "Junior Developer",
+        tech: "WebForms, MVC, SQL Server, MongoDB",
+        responsibilities: [
+            "Contributed to full-stack features",
+            "Worked with WebForms, MVC, SQL Server and MongoDB",
+        ],
+        tasks: "Contribución full-stack usando WebForms, MVC, SQL Server y MongoDB.",
+    },
 ];


### PR DESCRIPTION
## Summary
- include early roles in `experiences.ts`
- expose optional fields for job details
- show shared experience data on the Work page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p .` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea4bda24832e9bfd56dbc5aabea0